### PR TITLE
Use itertools helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,22 @@
 name = "solitaire"
 version = "0.1.0"
 dependencies = [
+ "itertools 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode_names 0.1.7 (git+https://github.com/antifuchs/unicode_names?branch=fix-for-rust-1-10)",
+]
+
+[[package]]
+name = "either"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itertools"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -25,6 +39,8 @@ version = "0.1.7"
 source = "git+https://github.com/antifuchs/unicode_names?branch=fix-for-rust-1-10#65bde7973ab5e947be403ec66edf765c33eeaa61"
 
 [metadata]
+"checksum either 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "63f94a35a9ca0d4178e85f0250373f2cea55c5d603e6993778d68a99b3d8071c"
+"checksum itertools 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d95557e7ba6b71377b0f2c3b3ae96c53f1b75a926a6901a500f557a370af730a"
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum unicode_names 0.1.7 (git+https://github.com/antifuchs/unicode_names?branch=fix-for-rust-1-10)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "solitaire"
 version = "0.1.0"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode_names 0.1.7 (git+https://github.com/antifuchs/unicode_names?branch=fix-for-rust-1-10)",
 ]
 
 [[package]]
@@ -18,6 +19,12 @@ dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "unicode_names"
+version = "0.1.7"
+source = "git+https://github.com/antifuchs/unicode_names?branch=fix-for-rust-1-10#65bde7973ab5e947be403ec66edf765c33eeaa61"
+
 [metadata]
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum unicode_names 0.1.7 (git+https://github.com/antifuchs/unicode_names?branch=fix-for-rust-1-10)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Martin Grenfell <martin.grenfell@gmail.com>"]
 
 [dependencies]
 rand = "*"
+unicode_names = { git = 'https://github.com/antifuchs/unicode_names', branch = 'fix-for-rust-1-10' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Martin Grenfell <martin.grenfell@gmail.com>"]
 [dependencies]
 rand = "*"
 unicode_names = { git = 'https://github.com/antifuchs/unicode_names', branch = 'fix-for-rust-1-10' }
+itertools = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 extern crate rand;
 extern crate unicode_names;
 #[macro_use] extern crate itertools;
+
 use rand::{thread_rng, Rng};
 use itertools::join;
+
 #[derive(Debug, Clone, Copy)]
 struct Card {
     suit: usize,
@@ -68,28 +70,42 @@ fn new_deck() -> Vec<Card> {
     ).collect::<Vec<_>>();
 }
 
-fn deal(deck: Vec<Card>) -> Vec<Vec<Card>> {
+struct Column {
+    cards: Vec<Card>,
+}
+
+struct Table {
+    columns: Vec<Column>,
+}
+
+fn deal(deck: Vec<Card>) -> Table {
     let mut columns = vec![];
     let mut start = 0;
     let mut end = 1;
     for column_number in 0..7 {
-        columns.push(deck[start..end].to_vec());
+        columns.push(
+            Column {
+                cards: deck[start..end].to_vec()
+            }
+        );
         start = end;
         end = end + 6 + column_number;
     }
-    return columns;
+    return Table {
+        columns: columns,
+    }
 }
 
-fn draw(columns: Vec<Vec<Card>>) {
-    let mut column_iterators = columns.iter().map(
+fn draw(table: Table) {
+    let mut column_iterators = table.columns.iter().map(
         |column| {
-            column.iter()
+            column.cards.iter()
         }
     ).collect::<Vec<_>>();
     print!(
         "\t{}\n\n",
         join(
-            (1..1+column_iterators.len()).map(|i| i.to_string()),
+            (1..1 + column_iterators.len()).map(|i| i.to_string()),
             "\t"
         )
     );
@@ -120,6 +136,6 @@ fn draw(columns: Vec<Vec<Card>>) {
 fn main() {
     let deck = new_deck();
     let shuffled_deck = shuffle(deck);
-    let columns = deal(shuffled_deck);
-    draw(columns);
+    let table = deal(shuffled_deck);
+    draw(table);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate rand;
 extern crate unicode_names;
 #[macro_use] extern crate itertools;
 use rand::{thread_rng, Rng};
+use itertools::join;
 #[derive(Debug, Clone, Copy)]
 struct Card {
     suit: usize,
@@ -85,6 +86,13 @@ fn draw(columns: Vec<Vec<Card>>) {
             column.iter()
         }
     ).collect::<Vec<_>>();
+    print!(
+        "\t{}\n\n",
+        join(
+            (1..1+column_iterators.len()).map(|i| i.to_string()),
+            "\t"
+        )
+    );
     let mut row_index = 0;
     loop {
         let mut row = format!("{}\t", row_index);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate rand;
 extern crate unicode_names;
 #[macro_use] extern crate itertools;
-
+use rand::{thread_rng, Rng};
 #[derive(Debug, Clone, Copy)]
 struct Card {
     suit: usize,
@@ -9,10 +9,12 @@ struct Card {
 }
 
 
-// fn shuffle(&mut self) {
-//     let mut rng = thread_rng();
-//     rng.shuffle(&mut self.cards);
-// }
+fn shuffle<T>(original_vector: Vec<T>) -> Vec<T> {
+    let mut shuffled_vector = original_vector;
+    let mut rng = thread_rng();
+    rng.shuffle(&mut shuffled_vector);
+    return shuffled_vector;
+}
 
 fn suit_name_by_index(suit_index: usize) -> Option<&'static str> {
     return match suit_index {
@@ -52,26 +54,29 @@ fn char_for_card(card: Card) -> Option<char>{
     return unicode_names::character(&unicode_name);
 }
 
-fn main() {
-    let mut row = 0;
+fn new_deck() -> Vec<Card>{
     let suits = 0..4;
     let ranks = 1..14;
-    let mut cards = iproduct!(suits, ranks).map(
+    return iproduct!(suits, ranks).map(
         |(suit_index, rank_index)| {
             Card {
                 suit: suit_index,
                 rank: rank_index,
             }
         }
-    );
+    ).collect::<Vec<_>>();
+}
 
+fn draw(deck: Vec<Card>) {
+    let mut cards = deck.iter();
+    let mut row = 0;
     for i in (0..7).cycle() {
         match cards.next() {
             Some(card) => {
                 if i == 0 {
                     print!("{}\t", row);
                 }
-                print!("{}", char_for_card(card).unwrap());
+                print!("{}", char_for_card(*card).unwrap());
                 if i == 6 {
                     row = row + 1;
                     print!("\n\n");
@@ -85,4 +90,10 @@ fn main() {
         }
     }
     print!("\n");
+}
+
+fn main() {
+    let deck = shuffle(new_deck());
+
+    draw(deck);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,170 +1,88 @@
 extern crate rand;
 extern crate unicode_names;
-
-
-use self::SUIT::*;
-use std::slice::Iter;
-use rand::{thread_rng, Rng};
-
-#[derive(Debug, Clone, Copy)]
-enum SUIT {
-    CLUB,
-    DIAMOND,
-    HEART,
-    SPADE,
-}
-
-impl SUIT {
-    pub fn iterator() -> Iter<'static, SUIT> {
-        static SUITS: [SUIT;  4] = [CLUB, DIAMOND, HEART, SPADE];
-        return SUITS.into_iter();
-    }
-
-    pub fn char_for(value: SUIT) -> &'static str {
-        return match value {
-            CLUB => "C",
-            DIAMOND => "D",
-            HEART => "H",
-            SPADE => "S"
-        }
-    }
-
-    pub fn name_for(value: SUIT) -> &'static str {
-        return match value {
-            CLUB => "CLUBS",
-            DIAMOND => "DIAMONDS",
-            HEART => "HEARTS",
-            SPADE => "SPADES"
-        }
-    }
-}
+#[macro_use] extern crate itertools;
 
 #[derive(Debug, Clone, Copy)]
 struct Card {
-    suit: SUIT,
-    rank: u8,
-}
-
-impl Card {
-    fn to_string(&self) -> String {
-        return format!("{}{}", SUIT::char_for(self.suit), self.rank);
-    }
-
-    fn as_char(&self) -> String {
-        let name: String = format!(
-            "PLAYING CARD {} OF {}",
-            self.rank_to_string(self.rank).to_string(),
-            SUIT::name_for(self.suit)
-        );
-        return self.char_for(name);
-    }
-
-    fn char_for(&self, name: String) -> String {
-        match unicode_names::character(&name) {
-            Some(c) => {
-                return c.to_string();
-            },
-            None => {
-                panic!(format!("unknown name {}", name));
-            }
-        }
-    }
-
-    fn rank_to_string(&self, rank: u8) -> &str {
-        match(rank) {
-            1 =>  { return "ACE" },
-            2 =>  { return "TWO" },
-            3 =>  { return "THREE" },
-            4 =>  { return "FOUR" },
-            5 =>  { return "FIVE" },
-            6 =>  { return "SIX" },
-            7 =>  { return "SEVEN" },
-            8 =>  { return "EIGHT" },
-            9 =>  { return "NINE" },
-            10 => { return "TEN" },
-            11 => { return "JACK" },
-            12 => { return "QUEEN" },
-            13 => { return "KING" },
-            _  => { panic!("should never see this") },
-        }
-    }
+    suit: usize,
+    rank: usize,
 }
 
 
-struct Pile {
-    hidden_index: usize,
-    cards: Vec<Card>,
-}
+// fn shuffle(&mut self) {
+//     let mut rng = thread_rng();
+//     rng.shuffle(&mut self.cards);
+// }
 
-
-struct Table {
-    piles: Vec<Pile>,
-}
-
-impl Table {
-    fn draw(&self) {
-        let mut row = 0;
-        loop {
-            let mut any_match = false;
-            for pile in self.piles.iter() {
-                match pile.cards.get(row) {
-                    Some(card) => {
-                        if row < pile.hidden_index {
-                            print!("{}", "X")
-                        } else {
-                            print!("{}", card.as_char());
-                        }
-                        any_match = true;
-                    },
-                    None => print!("."),
-                }
-                print!("\t")
-            }
-            print!("\n\n");
-            if ! any_match {
-                break;
-            }
-            row = row + 1;
-        }
+fn suit_name_by_index(suit_index: usize) -> Option<&'static str> {
+    return match suit_index {
+        0 => Some("CLUB"),
+        1 => Some("DIAMOND"),
+        2 => Some("HEART"),
+        3 => Some("SPADE"),
+        _ => None,
     }
 }
 
-
-struct Deck {
-    cards: Vec<Card>
-
+fn rank_name_by_index(rank_index: usize) -> Option<&'static str> {
+    return match rank_index {
+        1 => Some("ACE"),
+        2 => Some("TWO"),
+        3 => Some("THREE"),
+        4 => Some("FOUR"),
+        5 => Some("FIVE"),
+        6 => Some("SIX"),
+        7 => Some("SEVEN"),
+        8 => Some("EIGHT"),
+        9 => Some("NINE"),
+        10 => Some("TEN"),
+        11 => Some("JACK"),
+        12 => Some("QUEEN"),
+        13 => Some("KING"),
+        _ => None,
+    }
 }
 
-impl Deck {
-    pub fn new() -> Self {
-        let mut cards: Vec<Card> = vec![];
-        for suit in SUIT::iterator() {
-            for c in 1..14 {
-                cards.push(Card {rank: c, suit: *suit});
-            }
-        }
-        return Deck { cards: cards };
-    }
-
-    fn shuffle(&mut self) {
-        let mut rng = thread_rng();
-        rng.shuffle(&mut self.cards);
-    }
+fn char_for_card(card: Card) -> Option<char>{
+    let unicode_name = format!(
+        "PLAYING CARD {} OF {}S",
+        rank_name_by_index(card.rank).unwrap(),
+        suit_name_by_index(card.suit).unwrap(),
+    );
+    return unicode_names::character(&unicode_name);
 }
 
 fn main() {
-    let mut deck = Deck::new();
-    deck.shuffle();
-    let pile1 = Pile {cards: deck.cards[0..1].to_vec(), hidden_index: 0};
-    let pile2 = Pile {cards: deck.cards[1..7].to_vec(), hidden_index: 1};
-    let pile3 = Pile {cards: deck.cards[7..14].to_vec(), hidden_index: 2};
-    let pile4 = Pile {cards: deck.cards[14..22].to_vec(), hidden_index: 3};
-    let pile5 = Pile {cards: deck.cards[22..31].to_vec(), hidden_index: 4};
-    let pile6 = Pile {cards: deck.cards[31..41].to_vec(), hidden_index: 5};
-    let pile7 = Pile {cards: deck.cards[41..52].to_vec(), hidden_index: 6};
-    let piles = vec![
-        pile1, pile2, pile3, pile4, pile5, pile6, pile7,
-    ];
-    let t = Table{piles: piles};
-    t.draw();
+    let mut row = 0;
+    let suits = 0..4;
+    let ranks = 1..14;
+    let mut cards = iproduct!(suits, ranks).map(
+        |(suit_index, rank_index)| {
+            Card {
+                suit: suit_index,
+                rank: rank_index,
+            }
+        }
+    );
+
+    for i in (0..7).cycle() {
+        match cards.next() {
+            Some(card) => {
+                if i == 0 {
+                    print!("{}\t", row);
+                }
+                print!("{}", char_for_card(card).unwrap());
+                if i == 6 {
+                    row = row + 1;
+                    print!("\n\n");
+                } else {
+                    print!("\t");
+                }
+            },
+            None => {
+                break;
+            }
+        }
+    }
+    print!("\n");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ impl Card {
 
 
 struct Pile {
-    hidden_index: u8,
+    hidden_index: usize,
     cards: Vec<Card>,
 }
 
@@ -58,7 +58,11 @@ impl Table {
             for pile in self.piles.iter() {
                 match pile.cards.get(row) {
                     Some(card) => {
-                        print!("{}", card.to_string());
+                        if (row < pile.hidden_index) {
+                            print!("X");
+                        } else {
+                            print!("{}", card.to_string());
+                        }
                         any_match = true;
                     },
                     None => print!("."),
@@ -110,11 +114,6 @@ fn main() {
     let pile5 = Pile {cards: deck.cards[22..31].to_vec(), hidden_index: 4};
     let pile6 = Pile {cards: deck.cards[31..41].to_vec(), hidden_index: 5};
     let pile7 = Pile {cards: deck.cards[41..52].to_vec(), hidden_index: 6};
-    // let pile3 = Pile {cards: deck.cards, hidden_index: 0};
-    // let pile4 = Pile {cards: deck.cards, hidden_index: 0};
-    // let pile5 = Pile {cards: deck.cards, hidden_index: 0};
-    // let pile6 = Pile {cards: deck.cards, hidden_index: 0};
-    // let pile7 = Pile {cards: deck.cards, hidden_index: 0};
     let piles = vec![
         pile1, pile2, pile3, pile4, pile5, pile6, pile7,
     ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate unicode;
 extern crate rand;
 extern crate unicode_names;
 
@@ -52,7 +51,11 @@ impl Card {
     }
 
     fn as_char(&self) -> String {
-        let name: String = format!("PLAYING CARD {} OF {}", self.rank_to_string(self.rank).to_string(), SUIT::name_for(self.suit));
+        let name: String = format!(
+            "PLAYING CARD {} OF {}",
+            self.rank_to_string(self.rank).to_string(),
+            SUIT::name_for(self.suit)
+        );
         return self.char_for(name);
     }
 
@@ -62,7 +65,7 @@ impl Card {
                 return c.to_string();
             },
             None => {
-                return "X".to_string();
+                panic!(format!("unknown name {}", name));
             }
         }
     }
@@ -82,7 +85,7 @@ impl Card {
             11 => { return "JACK" },
             12 => { return "QUEEN" },
             13 => { return "KING" },
-            _  => { return "should never see this" },
+            _  => { panic!("should never see this") },
         }
     }
 }
@@ -117,7 +120,7 @@ impl Table {
                 }
                 print!("\t")
             }
-            print!("\n");
+            print!("\n\n");
             if ! any_match {
                 break;
             }
@@ -150,12 +153,6 @@ impl Deck {
 }
 
 fn main() {
-    let card = Card { suit: SUIT::DIAMOND, rank: 1 };
-    print!("{}", card.as_char());
-
-    print!("{}", unicode::char::UNICODE_VERSION);
-
-    //SUIT::char_for(DIAMOND);
     let mut deck = Deck::new();
     deck.shuffle();
     let pile1 = Pile {cards: deck.cards[0..1].to_vec(), hidden_index: 0};

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ fn new_deck() -> Vec<Card> {
 }
 
 struct Column {
+    hidden_index: usize,
     cards: Vec<Card>,
 }
 
@@ -85,7 +86,8 @@ fn deal(deck: Vec<Card>) -> Table {
     for column_number in 0..7 {
         columns.push(
             Column {
-                cards: deck[start..end].to_vec()
+                hidden_index: column_number,
+                cards: deck[start..end].to_vec(),
             }
         );
         start = end;
@@ -97,7 +99,7 @@ fn deal(deck: Vec<Card>) -> Table {
 }
 
 fn draw(table: Table) {
-    let mut column_iterators = table.columns.iter().map(
+    let mut column_card_iterators = table.columns.iter().map(
         |column| {
             column.cards.iter()
         }
@@ -105,7 +107,7 @@ fn draw(table: Table) {
     print!(
         "\t{}\n\n",
         join(
-            (1..1 + column_iterators.len()).map(|i| i.to_string()),
+            (1..1 + table.columns.len()).map(|i| i.to_string()),
             "\t"
         )
     );
@@ -113,13 +115,16 @@ fn draw(table: Table) {
     loop {
         let mut row = format!("{}\t", row_index);
         let mut card_found = false;
-        for column_iterator in column_iterators.iter_mut() {
-            let card_char = match column_iterator.next() {
+        for (column_index, column) in table.columns.iter().enumerate() {
+            let mut card_char = match column_card_iterators[column_index].next() {
                 Some(card) => {
                     card_found = true;
                     char_for_card(*card).unwrap()
                 },
                 None => '-',
+            };
+            if card_found && row_index < column.hidden_index {
+                card_char = 'X';
             };
             row = format!("{}{}\t", row, card_char);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
+extern crate unicode;
 extern crate rand;
+extern crate unicode_names;
+
+
 use self::SUIT::*;
 use std::slice::Iter;
 use rand::{thread_rng, Rng};
@@ -25,6 +29,15 @@ impl SUIT {
             SPADE => "S"
         }
     }
+
+    pub fn name_for(value: SUIT) -> &'static str {
+        return match value {
+            CLUB => "CLUBS",
+            DIAMOND => "DIAMONDS",
+            HEART => "HEARTS",
+            SPADE => "SPADES"
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -36,6 +49,41 @@ struct Card {
 impl Card {
     fn to_string(&self) -> String {
         return format!("{}{}", SUIT::char_for(self.suit), self.rank);
+    }
+
+    fn as_char(&self) -> String {
+        let name: String = format!("PLAYING CARD {} OF {}", self.rank_to_string(self.rank).to_string(), SUIT::name_for(self.suit));
+        return self.char_for(name);
+    }
+
+    fn char_for(&self, name: String) -> String {
+        match unicode_names::character(&name) {
+            Some(c) => {
+                return c.to_string();
+            },
+            None => {
+                return "X".to_string();
+            }
+        }
+    }
+
+    fn rank_to_string(&self, rank: u8) -> &str {
+        match(rank) {
+            1 =>  { return "ACE" },
+            2 =>  { return "TWO" },
+            3 =>  { return "THREE" },
+            4 =>  { return "FOUR" },
+            5 =>  { return "FIVE" },
+            6 =>  { return "SIX" },
+            7 =>  { return "SEVEN" },
+            8 =>  { return "EIGHT" },
+            9 =>  { return "NINE" },
+            10 => { return "TEN" },
+            11 => { return "JACK" },
+            12 => { return "QUEEN" },
+            13 => { return "KING" },
+            _  => { return "should never see this" },
+        }
     }
 }
 
@@ -59,9 +107,9 @@ impl Table {
                 match pile.cards.get(row) {
                     Some(card) => {
                         if row < pile.hidden_index {
-                            print!("X");
+                            print!("{}", "X")
                         } else {
-                            print!("{}", card.to_string());
+                            print!("{}", card.as_char());
                         }
                         any_match = true;
                     },
@@ -101,8 +149,11 @@ impl Deck {
     }
 }
 
-
 fn main() {
+    let card = Card { suit: SUIT::DIAMOND, rank: 1 };
+    print!("{}", card.as_char());
+
+    print!("{}", unicode::char::UNICODE_VERSION);
 
     //SUIT::char_for(DIAMOND);
     let mut deck = Deck::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,19 +86,17 @@ fn draw(columns: Vec<Vec<Card>>) {
     ).collect::<Vec<_>>();
     let mut row_index = 0;
     loop {
-        let mut card_found = false;
         let mut row = format!("{}\t", row_index);
+        let mut card_found = false;
         for column_iterator in column_iterators.iter_mut() {
-            match column_iterator.next() {
+            let card_char = match column_iterator.next() {
                 Some(card) => {
                     card_found = true;
-                    row = format!("{}{}", row, char_for_card(*card).unwrap());
+                    char_for_card(*card).unwrap()
                 },
-                None => {
-                    row = format!("{}-", row);
-                },
+                None => '-',
             };
-            row += "\t";
+            row = format!("{}{}\t", row, card_char);
         }
         if card_found {
             print!("{}\n\n", row);

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,10 +79,11 @@ fn deal(deck: Vec<Card>) -> Vec<Vec<Card>> {
 }
 
 fn draw(columns: Vec<Vec<Card>>) {
-    let mut column_iterators = vec![];
-    for column in columns.iter() {
-        column_iterators.push(column.iter());
-    }
+    let mut column_iterators = columns.iter().map(
+        |column| {
+            column.iter()
+        }
+    ).collect::<Vec<_>>();
     let mut row_index = 0;
     loop {
         let mut card_found = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,11 +69,12 @@ fn new_deck() -> Vec<Card> {
 
 fn deal(deck: Vec<Card>) -> Vec<Vec<Card>> {
     let mut columns = vec![];
-    for _ in 0..7 {
-        columns.push(vec![]);
-    }
-    for (card, column_index) in izip!(deck, (0..7).cycle()) {
-        columns[column_index].push(card);
+    let mut start = 0;
+    let mut end = 1;
+    for column_number in 0..7 {
+        columns.push(deck[start..end].to_vec());
+        start = end;
+        end = end + 6 + column_number;
     }
     return columns;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,23 +113,23 @@ fn draw(table: Table) {
     );
     let mut row_index = 0;
     loop {
-        let mut row = format!("{}\t", row_index);
+        let mut row = vec![row_index.to_string()];
         let mut card_found = false;
         for (column_index, column) in table.columns.iter().enumerate() {
             let mut card_char = match column_card_iterators[column_index].next() {
                 Some(card) => {
                     card_found = true;
-                    char_for_card(*card).unwrap()
+                    char_for_card(*card).unwrap().to_string()
                 },
-                None => '-',
+                None => "-".to_string(),
             };
             if card_found && row_index < column.hidden_index {
-                card_char = 'X';
+                card_char = "X".to_string();
             };
-            row = format!("{}{}\t", row, card_char);
+            row.push(card_char);
         }
         if card_found {
-            print!("{}\n\n", row);
+            print!("{}\n\n", join(row, "\t"));
         } else {
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ impl Table {
             for pile in self.piles.iter() {
                 match pile.cards.get(row) {
                     Some(card) => {
-                        if (row < pile.hidden_index) {
+                        if row < pile.hidden_index {
                             print!("X");
                         } else {
                             print!("{}", card.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn char_for_card(card: Card) -> Option<char>{
     return unicode_names::character(&unicode_name);
 }
 
-fn new_deck() -> Vec<Card>{
+fn new_deck() -> Vec<Card> {
     let suits = 0..4;
     let ranks = 1..14;
     return iproduct!(suits, ranks).map(
@@ -67,33 +67,51 @@ fn new_deck() -> Vec<Card>{
     ).collect::<Vec<_>>();
 }
 
-fn draw(deck: Vec<Card>) {
-    let mut cards = deck.iter();
-    let mut row = 0;
-    for i in (0..7).cycle() {
-        match cards.next() {
-            Some(card) => {
-                if i == 0 {
-                    print!("{}\t", row);
-                }
-                print!("{}", char_for_card(*card).unwrap());
-                if i == 6 {
-                    row = row + 1;
-                    print!("\n\n");
-                } else {
-                    print!("\t");
-                }
-            },
-            None => {
-                break;
-            }
+fn deal(deck: Vec<Card>) -> Vec<Vec<Card>> {
+    let mut columns = vec![];
+    for _ in 0..7 {
+        columns.push(vec![]);
+    }
+    for (card, column_index) in izip!(deck, (0..7).cycle()) {
+        columns[column_index].push(card);
+    }
+    return columns;
+}
+
+fn draw(columns: Vec<Vec<Card>>) {
+    let mut column_iterators = vec![];
+    for column in columns.iter() {
+        column_iterators.push(column.iter());
+    }
+    let mut row_index = 0;
+    loop {
+        let mut card_found = false;
+        let mut row = format!("{}\t", row_index);
+        for column_iterator in column_iterators.iter_mut() {
+            match column_iterator.next() {
+                Some(card) => {
+                    card_found = true;
+                    row = format!("{}{}", row, char_for_card(*card).unwrap());
+                },
+                None => {
+                    row = format!("{}-", row);
+                },
+            };
+            row += "\t";
         }
+        if card_found {
+            print!("{}\n\n", row);
+        } else {
+            break;
+        }
+        row_index += 1;
     }
     print!("\n");
 }
 
 fn main() {
-    let deck = shuffle(new_deck());
-
-    draw(deck);
+    let deck = new_deck();
+    let shuffled_deck = shuffle(deck);
+    let columns = deal(shuffled_deck);
+    draw(columns);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn rank_name_by_index(rank_index: usize) -> Option<&'static str> {
     }
 }
 
-fn char_for_card(card: Card) -> Option<char>{
+fn char_for_card(card: Card) -> Option<char> {
     let unicode_name = format!(
         "PLAYING CARD {} OF {}S",
         rank_name_by_index(card.rank).unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ impl SUIT {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 struct Card {
     suit: SUIT,
     rank: u8,
@@ -102,12 +103,20 @@ fn main() {
     //SUIT::char_for(DIAMOND);
     let mut deck = Deck::new();
     deck.shuffle();
-    let pile = Pile{cards: deck.cards, hidden_index: 0};
+    let pile1 = Pile {cards: deck.cards[0..1].to_vec(), hidden_index: 0};
+    let pile2 = Pile {cards: deck.cards[1..7].to_vec(), hidden_index: 1};
+    let pile3 = Pile {cards: deck.cards[7..14].to_vec(), hidden_index: 2};
+    let pile4 = Pile {cards: deck.cards[14..22].to_vec(), hidden_index: 3};
+    let pile5 = Pile {cards: deck.cards[22..31].to_vec(), hidden_index: 4};
+    let pile6 = Pile {cards: deck.cards[31..41].to_vec(), hidden_index: 5};
+    let pile7 = Pile {cards: deck.cards[41..52].to_vec(), hidden_index: 6};
+    // let pile3 = Pile {cards: deck.cards, hidden_index: 0};
+    // let pile4 = Pile {cards: deck.cards, hidden_index: 0};
+    // let pile5 = Pile {cards: deck.cards, hidden_index: 0};
+    // let pile6 = Pile {cards: deck.cards, hidden_index: 0};
+    // let pile7 = Pile {cards: deck.cards, hidden_index: 0};
     let piles = vec![
-        pile,
-        Pile {cards: vec![], hidden_index:0 },
-        Pile {cards: vec![], hidden_index:0 },
-        Pile {cards: vec![], hidden_index:0 },
+        pile1, pile2, pile3, pile4, pile5, pile6, pile7,
     ];
     let t = Table{piles: piles};
     t.draw();


### PR DESCRIPTION
I use itertools to:
 1. Create the deck of cards from the [cartesian product](https://docs.python.org/2/library/itertools.html#itertools.product) ( :smug-face: )  of suits and ranks.
 2. Ditched the use of Enums and replaced with functions that convert rank and suit integers to words that can be used to lookup a unicode playing card char.
 3. Re-implemented draw using iterators for each of the columns on the table.

See what you think 😄 

```
[richard@drax yukondoit]$ cargo run
    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/solitaire`
	1	2	3	4	5	6	7

0	🃎	X	X	X	X	X	X

1	-	🃕	X	X	X	X	X

2	-	🃇	🃗	X	X	X	X

3	-	🃂	🃒	🂻	X	X	X

4	-	🂭	🃓	🃙	🂽	X	X

5	-	🃁	🃈	🂦	🃋	🃆	X

6	-	-	🃅	🃚	🂪	🂺	🃉

7	-	-	-	🂫	🂸	🂹	🃞

8	-	-	-	-	🂷	🃖	🃍

9	-	-	-	-	-	🃘	🂤

10	-	-	-	-	-	-	🂩

```