### PR TITLE
Avoid copying Cards

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,6 @@ static RANKS: [Rank; 13] = [
     Rank{name: "KING"},
 ];
 
-#[derive(Clone)]
 struct Card {
     suit: &'static Suit,
     rank: &'static Rank,
@@ -71,26 +70,23 @@ impl Deck {
         };
     }
 
-    fn shuffle(&self) -> Deck {
-        let mut cards = self.cards.to_vec();
+    fn shuffle(mut self) -> Deck {
         let mut rng = thread_rng();
-        rng.shuffle(&mut cards);
-        return Deck {
-            cards: cards,
-        };
+        rng.shuffle(&mut self.cards);
+        return self;
     }
 }
 
-struct Column {
+struct Column <'a> {
     hidden_index: usize,
-    cards: Vec<Card>,
+    cards: Vec<&'a Card>,
 }
 
-struct Table {
-    columns: Vec<Column>,
+struct Table <'a> {
+    columns: Vec<Column<'a>>,
 }
 
-fn deal(deck: Deck) -> Table {
+fn deal(deck: &Deck) -> Table {
     let mut columns = vec![];
     let mut start = 0;
     let mut end = 1;
@@ -98,7 +94,7 @@ fn deal(deck: Deck) -> Table {
         columns.push(
             Column {
                 hidden_index: column_number,
-                cards: deck.cards[start..end].to_vec(),
+                cards: deck.cards[start..end].iter().collect(),
             }
         );
         start = end;
@@ -150,8 +146,7 @@ fn draw(table: Table) {
 }
 
 fn main() {
-    let deck = Deck::new()
-        .shuffle();
-    let table = deal(deck);
+    let deck = Deck::new().shuffle();
+    let table = deal(&deck);
     draw(table);
 }


### PR DESCRIPTION
I wanted to avoid copying Card instances so I removed the `Clone` trait.
Instead I operate on references to Cards which belong to a Deck which is owned by main.

I've been trying to understand reference lifetimes. 
I *think* that:
*  `Table` now has a lifetime parameter equal to the lifetime of the deck from which it is dealt.
* `Column` now has a lifetime parameter equal to the lifetime of its parent `Table`  
* So that the column has `Card` references with a lifetime equal to the deck which has the referenced cards.  

```
[richard@drax yukondoit]$ cargo run
    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/solitaire`
	0	1	2	3	4	5	6

0	🂡	X	X	X	X	X	X

1	-	🂾	X	X	X	X	X

2	-	🂨	🂲	X	X	X	X

3	-	🂦	🃛	🃞	X	X	X

4	-	🂹	🂣	🂫	🃍	X	X

5	-	🃃	🂽	🃝	🂴	🂺	X

6	-	-	🃗	🂪	🃂	🃊	🃖

7	-	-	-	🃎	🃁	🃘	🃇

8	-	-	-	-	🃆	🃒	🂢

9	-	-	-	-	-	🃅	🂵

10	-	-	-	-	-	-	🂤

```

No tests yet 😦 